### PR TITLE
Add support for `prefersEmptyArrayForUndefinedContentTypes`

### DIFF
--- a/Slots/Slots.swift
+++ b/Slots/Slots.swift
@@ -47,6 +47,16 @@ public class Slots: NSObject {
         return self._contents.count
     }
 
+    /// if set to `true`, subscript will return empty array(`[]`) instead of `nil` for undefined content types. Default
+    /// value is `false`.
+    ///
+    /// Example::
+    ///
+    ///   slots["undefined"] // nil
+    ///   slots.prefersEmptyArrayForUndefinedContentTypes = true
+    ///   slots["undefined"] // []
+    public var prefersEmptyArrayForUndefinedContentTypes = false
+
 
     // MARK: - Init
 
@@ -98,7 +108,11 @@ public class Slots: NSObject {
 
     public subscript(type: String) -> [AnyObject]? {
         get {
-            return self._contentsForType[type]
+            let contents = self._contentsForType[type]
+            if self.prefersEmptyArrayForUndefinedContentTypes {
+                return contents ?? []
+            }
+            return contents
         }
         set {
             self._contentsForType[type] = newValue

--- a/SlotsTests/SlotsTests.swift
+++ b/SlotsTests/SlotsTests.swift
@@ -181,4 +181,13 @@ class SlotsTests: XCTestCase {
         XCTAssert(self.slots.typeAtIndex(6) == nil)
     }
 
+    func testUndefinedContentType() {
+        XCTAssert(self.slots["undefined"] == nil)
+    }
+
+    func testPrefersEmptyArrayForUndefinedContentTypes() {
+        self.slots.prefersEmptyArrayForUndefinedContentTypes = true
+        XCTAssert(self.slots["undefined"] != nil)
+    }
+
 }


### PR DESCRIPTION
If set to `true`, subscript will return empty array(`[]`) instead of `nil` for undefined content types. Default value is `false`.

It's more convenience than setting default values of each content types.

For example:

``` swift
slots.prefersEmptyArrayForUndefinedContentTypes = false // default
slots["undefined"] // nil
slots.prefersEmptyArrayForUndefinedContentTypes = true
slots["undefined"] // []
```
