### PR TITLE
Add support for Swift 1.2

### DIFF
--- a/Slots/Slots.swift
+++ b/Slots/Slots.swift
@@ -146,12 +146,12 @@ public class Slots: NSObject {
             stacks[type] = reverse(contents)
         }
 
-        var repeatableTypes = NSMutableSet()
+        var repeatableTypes = Set<String>()
         if let repeatables = self.repeatables {
-            repeatableTypes.intersectSet(NSSet(array: self.pattern))
+            repeatableTypes.intersect(Set(self.pattern))
             for type in self.pattern {
                 if contains(repeatables, type) {
-                    repeatableTypes.addObject(type)
+                    repeatableTypes.insert(type)
                 }
             }
         }
@@ -160,8 +160,8 @@ public class Slots: NSObject {
             var nonRepeatableFinished = false
             for type in from {
                 if stacks[type]? == nil || stacks[type]!.count == 0 {
-                    if repeatableTypes.containsObject(type) {
-                        repeatableTypes.removeObject(type)
+                    if repeatableTypes.contains(type) {
+                        repeatableTypes.remove(type)
                     } else {
                         nonRepeatableFinished = true
                     }
@@ -171,7 +171,7 @@ public class Slots: NSObject {
                     continue
                 }
 
-                if !nonRepeatableFinished || repeatableTypes.containsObject(type) {
+                if !nonRepeatableFinished || repeatableTypes.contains(type) {
                     let last: AnyObject = stacks[type]!.removeLast()
                     self._patterns.append(type)
                     self._contents.append(last)

--- a/Slots/Slots.swift
+++ b/Slots/Slots.swift
@@ -101,7 +101,7 @@ public class Slots: NSObject {
         return self._contents[index]
     }
 
-    public subscript(subRange: Range<Int>) -> Slice<AnyObject> {
+    public subscript(subRange: Range<Int>) -> ArraySlice<AnyObject> {
         self.sortIfNeeded()
         return self._contents[subRange]
     }

--- a/Slots/Slots.swift
+++ b/Slots/Slots.swift
@@ -159,7 +159,7 @@ public class Slots: NSObject {
         let enumerate = { (from: [String]) -> Bool in
             var nonRepeatableFinished = false
             for type in from {
-                if stacks[type]? == nil || stacks[type]!.count == 0 {
+                if stacks[type] == nil || stacks[type]!.count == 0 {
                     if repeatableTypes.contains(type) {
                         repeatableTypes.remove(type)
                     } else {

--- a/SlotsTests/SlotsTests.swift
+++ b/SlotsTests/SlotsTests.swift
@@ -67,7 +67,7 @@ class SlotsTests: XCTestCase {
         self.slots["odd"] = [1, 3]
         expected = [2, 4, 1, 6, 8, 3]
         for i in 0..<self.slots.count {
-            XCTAssertEqual(self.slots[i] as Int, expected[i])
+            XCTAssertEqual(self.slots[i] as! Int, expected[i])
         }
         XCTAssertNil(self.slots[6])
 
@@ -77,7 +77,7 @@ class SlotsTests: XCTestCase {
         self.slots["mod-2"] = [2, 5, 8]
         expected = [0, 1, 2, 3]
         for i in 0..<self.slots.count {
-            XCTAssertEqual(self.slots[i] as Int, expected[i])
+            XCTAssertEqual(self.slots[i] as! Int, expected[i])
         }
 
         self.slots.pattern = ["mod-0", "mod-1", "mod-1", "mod-2"]
@@ -86,7 +86,7 @@ class SlotsTests: XCTestCase {
         self.slots["mod-2"] = [2, 5, 8]
         expected = [0, 1, 4, 2, 3, 7, 10, 5, 6, 13]
         for i in 0..<self.slots.count {
-            XCTAssertEqual(self.slots[i] as Int, expected[i])
+            XCTAssertEqual(self.slots[i] as! Int, expected[i])
         }
     }
 
@@ -96,7 +96,7 @@ class SlotsTests: XCTestCase {
         self.slots["even"] = [2, 4, 6, 8, 10, 12, 14, 16]
         self.slots["odd"] = [1, 3]
         XCTAssertEqual(self.slots.count, 8)
-        XCTAssertEqual(self.slots.contents as [Int], [2, 4, 1, 6, 8, 3, 10, 12])
+        XCTAssertEqual(self.slots.contents as! [Int], [2, 4, 1, 6, 8, 3, 10, 12])
 
         self.slots.pattern = ["even", "even", "odd"]
         self.slots.repeatables = ["even"]
@@ -124,8 +124,8 @@ class SlotsTests: XCTestCase {
         let odds = [1, 3, 5]
         self.slots["even"] = evens
         self.slots["odd"] = odds
-        XCTAssertEqual(evens, self.slots["even"] as [Int])
-        XCTAssertEqual(odds, self.slots["odd"] as [Int])
+        XCTAssertEqual(evens, self.slots["even"] as! [Int])
+        XCTAssertEqual(odds, self.slots["odd"] as! [Int])
     }
 
     func testHeader() {
@@ -135,7 +135,7 @@ class SlotsTests: XCTestCase {
         self.slots["odd"] = [1, 3, 5]
         let expected = [2, 4, 6, 8, 1, 10, 3, 12, 5, 14]
         for i in 0..<self.slots.count {
-            XCTAssertEqual(self.slots[i] as Int, expected[i])
+            XCTAssertEqual(self.slots[i] as! Int, expected[i])
         }
     }
 
@@ -146,7 +146,7 @@ class SlotsTests: XCTestCase {
         self.slots["odd"] = [1, 3, 5]
         let expected = [2, 1, 4, 3, 6, 5, 8]
         for i in 0..<self.slots.count {
-            XCTAssertEqual(self.slots[i] as Int, expected[i])
+            XCTAssertEqual(self.slots[i] as! Int, expected[i])
         }
     }
 


### PR DESCRIPTION
- Replace `Slice` with `ArraySlice`
- Replace `NSSet` with Swift `Set`
- Cast AnyObject with a brand-new keyword `as!`
